### PR TITLE
Use autocomplete attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ So, I felt the need to develop this tool that does the dirty job for me :D
 
 All the data generation happens locally. So, Autofillr does not send any requests to a remote service or api. Thanks to the libraries like [Faker.js](https://github.com/marak/Faker.js/).
 
-To fill in the forms on websites, it uses a list of html ids for each input field.
+To fill in the forms on websites, it uses [the HTML autocomplete attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete).
 
 Here is an example form that Autofillr can fill in: [codesandbox](https://8vc76.csb.app/)
 

--- a/src/conf/de.js
+++ b/src/conf/de.js
@@ -2,54 +2,49 @@ import { getName, getEmail, getDateOfBirth } from '../utils/faker';
 import { getFormattedDate, getRandomDigits } from '../utils/utils';
 
 function generate() {
-  const { firstName, familyName, prefix } = getName();
+  const { firstName, familyName } = getName();
 
   return {
     firstName: {
       title: 'First Name',
       value: firstName,
-      ids: ['given_name'],
+      autocomplete: 'given-name',
     },
     familyName: {
       title: 'Family Name',
       value: familyName,
-      ids: ['family_name'],
+      autocomplete: 'family-name',
     },
     email: {
       title: 'Email',
       value: getEmail(firstName, familyName),
-      ids: ['email'],
-    },
-    title: {
-      title: 'Title', // way so many titles :))
-      value: prefix,
-      ids: ['5cdd013a-1db1-4f89-9cd4-b8bd9807c732'],
+      autocomplete: 'email',
     },
     address: {
       title: 'Address',
       value: 'Panoramastraße 1A',
-      ids: ['street_address'],
+      autocomplete: 'address-line1',
     },
     postalCode: {
       title: 'Postal Code',
       value: '10178',
-      ids: ['postal_code'],
+      autocomplete: 'postal-code',
     },
     city: {
       title: 'City',
       value: 'Berlin',
-      ids: ['city'],
+      autocomplete: 'address-level2',
     },
     // https://en.wikipedia.org/wiki/Telephone_numbers_in_Germany#Geographic_numbering
     phone: {
       title: 'Phone',
       value: `+4930${getRandomDigits(8)}`, // 30 is the geographic area code of Berlin.
-      ids: ['phone'],
+      autocomplete: 'tel',
     },
     dateOfBirth: {
       title: 'Date of Birth',
       value: getFormattedDate(getDateOfBirth()),
-      ids: ['date_of_birth'],
+      autocomplete: 'bday',
     },
   };
 }

--- a/src/conf/it.js
+++ b/src/conf/it.js
@@ -20,53 +20,53 @@ function generate() {
     firstName: {
       title: 'First Name',
       value: firstName,
-      ids: ['given_name'],
+      autocomplete: 'given-name',
     },
     familyName: {
       title: 'Family Name',
       value: familyName,
-      ids: ['family_name'],
+      autocomplete: 'family-name',
     },
     email: {
       title: 'Email',
       value: getEmail(firstName, familyName),
-      ids: ['email'],
+      autocomplete: 'email',
     },
     nationalId: {
       title: 'Fiscal Code',
       value: fiscalCode,
-      ids: ['national_identification_number', 'nin'],
+      autocomplete: 'nin',
     },
     address: {
       title: 'Address',
       value: 'Piazza del Colosseo 1',
-      ids: ['street_address'],
+      autocomplete: 'address-line1',
     },
     postalCode: {
       title: 'Postal Code',
       value: '00184',
-      ids: ['postal_code'],
+      autocomplete: 'postal-code',
     },
     city: {
       title: 'City',
       value: 'Roma',
-      ids: ['city'],
+      autocomplete: 'address-level2',
     },
     region: {
       title: 'Province',
       value: 'RM',
-      ids: ['region'],
+      autocomplete: 'address-level1',
     },
     // https://en.wikipedia.org/wiki/Telephone_numbers_in_Italy#Landline_service
     phone: {
       title: 'Phone',
       value: `+3906${getRandomDigits(8)}`, // 06 is the geographical code of Rome.
-      ids: ['phone'],
+      autocomplete: 'tel',
     },
     dateOfBirth: {
       title: 'Date of Birth',
       value: getFormattedDate(dateOfBirth),
-      ids: ['date_of_birth'],
+      autocomplete: 'bday',
     },
   };
 }

--- a/src/conf/nl.js
+++ b/src/conf/nl.js
@@ -2,54 +2,49 @@ import { getName, getEmail, getDateOfBirth } from '../utils/faker';
 import { getFormattedDate, getRandomDigits } from '../utils/utils';
 
 function generate() {
-  const { firstName, familyName, prefix } = getName();
+  const { firstName, familyName } = getName();
 
   return {
     firstName: {
       title: 'First Name',
       value: firstName,
-      ids: ['given_name'],
+      autocomplete: 'given-name',
     },
     familyName: {
       title: 'Family Name',
       value: familyName,
-      ids: ['family_name'],
+      autocomplete: 'family-name',
     },
     email: {
       title: 'Email',
       value: getEmail(firstName, familyName),
-      ids: ['email'],
-    },
-    title: {
-      title: 'Title', // way so many titles :))
-      value: prefix,
-      ids: ['5cdd013a-1db1-4f89-9cd4-b8bd9807c732'],
+      autocomplete: 'email',
     },
     address: {
       title: 'Address',
       value: 'Museumplein 6',
-      ids: ['street_address'],
+      autocomplete: 'address-line1',
     },
     postalCode: {
       title: 'Postal Code',
       value: '1071 DJ',
-      ids: ['postal_code'],
+      autocomplete: 'postal-code',
     },
     city: {
       title: 'City',
       value: 'Amsterdam',
-      ids: ['city'],
+      autocomplete: 'address-level2',
     },
     // https://en.wikipedia.org/wiki/Telephone_numbers_in_the_Netherlands#Geographical_telephone_numbers
     phone: {
       title: 'Phone',
       value: `+3120${getRandomDigits(7)}`, // 20 is Amsterdam's geographical number.
-      ids: ['phone'],
+      autocomplete: 'tel',
     },
     dateOfBirth: {
       title: 'Date of Birth',
       value: getFormattedDate(getDateOfBirth()),
-      ids: ['date_of_birth'],
+      autocomplete: 'bday',
     },
   };
 }

--- a/src/conf/se.js
+++ b/src/conf/se.js
@@ -10,43 +10,43 @@ function generate() {
     firstName: {
       title: 'First Name',
       value: firstName,
-      ids: ['given_name'],
+      autocomplete: 'given-name',
     },
     familyName: {
       title: 'Family Name',
       value: familyName,
-      ids: ['family_name'],
+      autocomplete: 'family-name',
     },
     email: {
       title: 'Email',
       value: getEmail(firstName, familyName),
-      ids: ['email'],
+      autocomplete: 'email',
     },
     nationalId: {
       title: 'National ID',
       value: generatePno(),
-      ids: ['national_identification_number', 'nin'],
+      autocomplete: 'nin',
     },
     address: {
       title: 'Address',
       value: 'Galärvarvsvägen 14',
-      ids: ['street_address'],
+      autocomplete: 'address-line1',
     },
     postalCode: {
       title: 'Postal Code',
       value: '115 21',
-      ids: ['postal_code'],
+      autocomplete: 'postal-code',
     },
     city: {
       title: 'City',
       value: 'Stockholm',
-      ids: ['city'],
+      autocomplete: 'address-level2',
     },
     // https://en.wikipedia.org/wiki/Telephone_numbers_in_Sweden#Area_codes
     phone: {
       title: 'Phone',
       value: `+468${getRandomDigits(8)}`, // 8 is the are code of Stockholm.
-      ids: ['phone'],
+      autocomplete: 'tel',
     },
   };
 }

--- a/src/contentScripts/content.js
+++ b/src/contentScripts/content.js
@@ -13,7 +13,6 @@ const fillAvailableFields = (request, _sender, sendResponse) => {
   clearInputs();
   Object.values(request).forEach(({ value, autocomplete }) => {
     try {
-      // fill any input tag whose id attribute contains `fieldId`
       const target = document.querySelectorAll(`input[autocomplete*='${autocomplete}']`)[0];
       target.dispatchEvent(new Event('focus', { bubbles: true }));
       target.value = value;

--- a/src/contentScripts/content.js
+++ b/src/contentScripts/content.js
@@ -16,8 +16,6 @@ const fillAvailableFields = (request, _sender, sendResponse) => {
       // fill any input tag whose id attribute contains `fieldId`
       const target = document.querySelectorAll(`input[autocomplete*='${autocomplete}']`)[0];
       target.dispatchEvent(new Event('focus', { bubbles: true }));
-      target.value = '';
-      target.dispatchEvent(new Event('input', { bubbles: true }));
       target.value = value;
       target.dispatchEvent(new Event('input', { bubbles: true }));
       target.dispatchEvent(new Event('blur', { bubbles: true }));

--- a/src/contentScripts/content.js
+++ b/src/contentScripts/content.js
@@ -1,19 +1,29 @@
+const clearInputs = () => {
+  const inputs = document.querySelectorAll('input[autocomplete]');
+  inputs.forEach((target) => {
+    target.dispatchEvent(new Event('focus', { bubbles: true }));
+    // eslint-disable-next-line no-param-reassign
+    target.value = '';
+    target.dispatchEvent(new Event('input', { bubbles: true }));
+    target.dispatchEvent(new Event('blur', { bubbles: true }));
+  });
+};
+
 const fillAvailableFields = (request, _sender, sendResponse) => {
-  Object.values(request).forEach(({ value, ids }) => {
-    ids.forEach((fieldId) => {
-      try {
-        // fill any input tag whose id attribute contains `fieldId`
-        const target = document.querySelectorAll(`input[id*='${fieldId}']`)[0];
-        target.dispatchEvent(new Event('focus', { bubbles: true }));
-        target.value = '';
-        target.dispatchEvent(new Event('input', { bubbles: true }));
-        target.value = value;
-        target.dispatchEvent(new Event('input', { bubbles: true }));
-        target.dispatchEvent(new Event('blur', { bubbles: true }));
-      } catch (e) {
-        // let's pretend like nothing has happened
-      }
-    });
+  clearInputs();
+  Object.values(request).forEach(({ value, autocomplete }) => {
+    try {
+      // fill any input tag whose id attribute contains `fieldId`
+      const target = document.querySelectorAll(`input[autocomplete*='${autocomplete}']`)[0];
+      target.dispatchEvent(new Event('focus', { bubbles: true }));
+      target.value = '';
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+      target.value = value;
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+      target.dispatchEvent(new Event('blur', { bubbles: true }));
+    } catch (e) {
+      // let's pretend like nothing has happened
+    }
   });
 
   sendResponse('the form is filled');


### PR DESCRIPTION
Use html autocomplete attribute to fill in the forms. The autocomplete attribute is more universal than a constant set of ids.

https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete

https://developers.google.com/web/updates/2015/06/checkout-faster-with-autofill

## How to test?

Checkout this branch, build the project (`yarn build`) and load the unpacked extension in google chrome by pointing the build file as described in the readme. After that the extension can be tested on address forms.